### PR TITLE
Containerized Python and Node apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/.git
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM nikolaik/python-nodejs:python3.10-nodejs18-bullseye
+
+RUN apt update \
+ && apt install -y \
+  build-essential \
+  libeigen3-dev \
+  libgmp-dev \
+  libgmpxx4ldbl \
+  libmpfr-dev \
+  libboost-dev \
+  libboost-thread-dev \
+  libtbb-dev \
+  python3-dev \
+  libgdal-dev \
+  gdal-bin \
+  python3-gdal
+
+#ADD . /app
+
+ADD setup.py /app/
+ADD web_app/package*.json /app/web_app/
+
+WORKDIR /app
+
+RUN python -V
+
+# gdal==3.0.4 requires setuptools==57.5.0
+# gdal requires numpy to be installed first so that it can detect and build extensions
+RUN pip install setuptools==57.5.0 \
+ && pip install numpy \
+ && pip install .
+
+RUN cd web_app \
+ && npm install
+
+ADD . /app
+
+# web_app: 3000, server/main.py: 8000
+EXPOSE 3000 8000
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["python3", "server/main.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	apt-get install \
+	apt-get install -y \
 		libeigen3-dev \
 		libgmp-dev \
 		libgmpxx4ldbl \
@@ -8,4 +8,14 @@ install:
 		libboost-thread-dev \
 		libtbb-dev \
 		python3-dev \
-		gdal
+		libgdal-dev \
+		gdal-bin
+
+install-mac:
+	brew install gdal --HEAD
+
+image:
+	docker build . -t terrain_viewer
+
+run:
+	docker run --rm -p 3000:3000 -p 8000:8000 --name terrain_viewer terrain_viewer

--- a/README.md
+++ b/README.md
@@ -9,12 +9,20 @@ then run `python ./fillnodata.py` to fill the nodata values with the mean of the
 
 ## Install dependencies
 ```bash
-make install   # to install dependencies
-pip install .  # to install python packages
+make install        # to install dependencies for Linux
+# make install-mac  # to install dependencies for OSX
+pip install .       # to install python packages
 ```
 
 ## Testing
 - run `./main.py` to generate two stl files (golden hinde and vancouver island)
 - view STLs here: https://www.viewstl.com/
 - it should render something like this:
-![example vancouver island](./docs/vancouver_island.png)- 
+![example vancouver island](./docs/vancouver_island.png)-
+
+## Docker
+
+```bash
+make image
+make run
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Starting web server..."
+
+npm --prefix web_app start &
+
+echo "Starting python server..."
+
+exec "$@"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_packages, setup
 
 packages = [
     "gdal==3.0.4",
+    "setuptools==57.5.0",
     "numpy",
     "numpy-stl",
     "shapely",
@@ -29,7 +30,7 @@ linting_packages = [
 ]
 
 setup(
-    name="Terrain Viewerr",
+    name="Terrain Viewer",
     version="1.0",
     description="returning STL files from a region",
     author="John Oram",

--- a/stl_generator/stl_util.py
+++ b/stl_generator/stl_util.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 from shapely.geometry import Polygon, Point
 
-from geotiff import GeoTIFFS
+from .geotiff import GeoTIFFS
 from stl import mesh
 
 geoTIFFS = GeoTIFFS()


### PR DESCRIPTION
First pass at containerization, both FE and BE are wrapped up together.

There were several errors between GCC, Debian, Python and GDAL while setting this up - the Dockerfile install steps and setup.py changes are executed in particular order to avoid these problems.

Linux users probably don't need this containerization, but it may be useful for Mac & Windows environments.

Future improvements might include splitting the web_app from the Python server, layer compacting, and pushing to gchr.io.

Give it a test!

```sh
make image
make run
# http://localhost:3000 for web frontend
# http://localhost:8000 for Python backend
```